### PR TITLE
escape single qote in "Here's an article"

### DIFF
--- a/j4x-api-complete-collection.postman_collection.json
+++ b/j4x-api-complete-collection.postman_collection.json
@@ -1090,7 +1090,7 @@
 				],
 				"body": {
 					"mode": "raw",
-					"raw": "{'alias': 'my-article','articletext': 'My text','catid': 64,'language': '*','metadesc': '','metakey': '','title': 'Here's an article'}"
+					"raw": "{'alias': 'my-article','articletext': 'My text','catid': 64,'language': '*','metadesc': '','metakey': '','title': 'Here\\'s an article'}"
 				},
 				"url": {
 					"raw": "{{base_path}}/api/index.php/v1/content/articles",


### PR DESCRIPTION
(partially) Fixes #12
Only in "raw" body, not in CURL example