### PR TITLE
Syntax error in collection

### DIFF
--- a/j4x-api-complete-collection.postman_collection.json
+++ b/j4x-api-complete-collection.postman_collection.json
@@ -1105,7 +1105,7 @@
 						"article"
 					]
 				},
-				"description": "Generated from a curl request: \ncurl -X POST -H 'Content-Type: application/json' '{{base_path}}/api/index.php/v1/content/articles' -d \\\"{'alias': 'my-article','articletext': 'My text','catid': 64,'language': '*','metadesc': '','metakey': '','title': 'Here\'s an article'}\\\""
+				"description": "Generated from a curl request: \ncurl -X POST -H 'Content-Type: application/json' '{{base_path}}/api/index.php/v1/content/articles' -d \\\"{'alias': 'my-article','articletext': 'My text','catid': 64,'language': '*','metadesc': '','metakey': '','title': 'Here\\'s an article'}\\\""
 			},
 			"response": []
 		},


### PR DESCRIPTION
After [last our change](https://github.com/alexandreelise/j4x-api-collection/commit/c5fdd1058729c4dc076da65681ae7c76f34d6936) collection can't be imported. Should be double backslash. 

![image](https://user-images.githubusercontent.com/11570/137711590-eccb6369-fed2-4352-b475-4d4763c631f3.png)